### PR TITLE
Removed large image on homepage

### DIFF
--- a/app/views/public/swagger/index.html.erb
+++ b/app/views/public/swagger/index.html.erb
@@ -3,7 +3,7 @@
 
   <h1 class="page-title">U.S. Digital Registry</h1>
   <h2>What is the U.S. Digital Registry?</h2>
-  <p><%= image_tag "top_banner_public", alt: "image of hand holding a mobile phone", id: "top-banner" %></p>
+
   <div style="margin: 10px; padding: 10px; border: 1px solid black;">
  <p><b>Notice:</b> As of April 19, 2018, all entries that have not been updated by agencies since <b>January 1, 2017</b> have been archived. Archived accounts will not appear in the public facing list and API of official, active accounts. This was done to help ensure that users can trust that accounts listed in the U.S. Digital Registry as official are still active.
 
@@ -25,7 +25,7 @@
     <li>Tags, as self-identified by agencies</li>
   </ul>
   <p>For customer service on accounts, please contact their programs directly. </p>
-  
+
   <div role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active"><a href="#search_social" aria-controls="home" role="tab" data-toggle="tab">Search Social Media Accounts</a></li>
@@ -169,8 +169,8 @@
       </div>
     </div>
   </div>
-    
-  
+
+
   <h2>What's "Official"?</h2>
   <p>The U.S. Digital Registry only includes accounts that represent official U.S. government agencies, organizations, or programs — the collection grows daily. You can register accounts managed by federal agencies, heads of agencies or members of the President’s Cabinet. <b>Do not enter personal, employee, or other types of accounts.</b></p>
   <h2>For Developers: Using and Improving the API</h2>
@@ -302,7 +302,7 @@
 </script>
 
 
-  <script>  
+  <script>
   Handlebars.registerHelper('formatDate', function(date){
     if(date.data.root){
       var d = new Date(date.data.root.updated_at);
@@ -320,17 +320,17 @@
     }
     return array_of_text.join(", ");
   });
-  
+
   var source_social_media_template   = $("#social-media-template").html();
-  var social_media_template = Handlebars.compile(source_social_media_template); 
+  var social_media_template = Handlebars.compile(source_social_media_template);
 
 
   var source_mobile_template   = $("#mobile-template").html();
-  var mobile_template = Handlebars.compile(source_mobile_template); 
+  var mobile_template = Handlebars.compile(source_mobile_template);
 
   var source_metadata_template = $('#metadata-template').html();
   var metadata_template = Handlebars.compile(source_metadata_template);
-    
+
 
   $(document).ready(function(){
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
@@ -341,7 +341,7 @@
     $('#social-media-search').submit(function(e){
       e.preventDefault();
       submit_social_media_form();
-      
+
     });
     $('#previousPage').click(function(e){
       e.preventDefault();
@@ -350,7 +350,7 @@
         $('#search-social-page').val(page_int - 1);
       }else{
         $('#search-social-page').val(1)
-      } 
+      }
       submit_social_media_form();
     });
     $('#nextPage').click(function(e){


### PR DESCRIPTION
## What we made better

I removed the image at the top of the page because it is way too big and not essential to delivering the critical information on the page.